### PR TITLE
AWS ECS 배포 설정 추가

### DIFF
--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -1,0 +1,49 @@
+name: nginx
+on:
+  push:
+    branches: [ master ]
+  release:
+    type: [ published ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v1
+        id: login-ecr
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG nginx
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        id: task-def
+        with:
+          task-definition: ./nginx/task-definition.json
+          container-name: nginx
+          image: ${{ steps.build-image.outputs.image }}
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ secrets.AWS_ECS_GRADLE_SERVICE }}
+          cluster: ${{ secrets.AWS_ECS_CLUSTER }}
+          wait-for-service-stability: true

--- a/.github/workflows/webchat.yml
+++ b/.github/workflows/webchat.yml
@@ -1,7 +1,7 @@
 name: Web-Chat
 on:
   push:
-    branches: [  master ]
+    branches: [ master ]
   release:
     type: [ published ]
 jobs:
@@ -39,7 +39,7 @@ jobs:
           ECR_REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg url=${{ secrets.AWS_RDS_URL }} --build-arg username=${{ secrets.AWS_RDS_USERNAME }} --build-arg password=${{ secrets.AWS_RDS_PASSWORD }} .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
@@ -55,6 +55,6 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: ${{ secrets.AWS_ECS_SERVICE }}
+          service: ${{ secrets.AWS_ECS_WEBCHAT_SERVICE }}
           cluster: ${{ secrets.AWS_ECS_CLUSTER }}
           wait-for-service-stability: true

--- a/.github/workflows/webchat.yml
+++ b/.github/workflows/webchat.yml
@@ -1,0 +1,60 @@
+name: Web-Chat
+on:
+  push:
+    branches: [  master ]
+  release:
+    type: [ published ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v1
+        id: login-ecr
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        id: task-def
+        with:
+          task-definition: task-definition.json
+          container-name: webchat
+          image: ${{ steps.build-image.outputs.image }}
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ secrets.AWS_ECS_SERVICE }}
+          cluster: ${{ secrets.AWS_ECS_CLUSTER }}
+          wait-for-service-stability: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# docker build -t web-chat .
+# docker run --name webchat -d -p 8089:8089 webchat
+FROM ubuntu
+FROM openjdk:11
+
+COPY ./build/libs/ /home/user/webchat/
+
+WORKDIR /home/user/webchat/
+
+ENTRYPOINT [ "sh", "-c", "java -jar -Dspring.profiles.active=dev web-chat-backend-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
-# docker build -t web-chat .
-# docker run --name webchat -d -p 8089:8089 webchat
+# docker build -t web-chat --build-arg url='' --build-arg username='' --build-arg password='' .
+# docker run --name webchat -d -p 8080:8080 webchat
 FROM ubuntu
 FROM openjdk:11
+
+ARG url
+ARG username
+ARG password
 
 COPY ./build/libs/ /home/user/webchat/
 
 WORKDIR /home/user/webchat/
 
-ENTRYPOINT [ "sh", "-c", "java -jar -Dspring.profiles.active=dev web-chat-backend-0.0.1-SNAPSHOT.jar"]
+ENV RUNNER "java -jar -Dspring.profiles.active=dev -Dspring.datasource.url=${url}  -Dspring.datasource.username=${username} -Dspring.datasource.password=${password} web-chat-backend-0.0.1-SNAPSHOT.jar"
+
+ENTRYPOINT [ "sh", "-c", "$RUNNER"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,6 @@
+# docker build -t nginx ./nginx
+# docker run --name nginx -d -p 8080:80 -v front:/front:ro --link web-chat nginx
+FROM nginx
+
+COPY mime.types /etc/nginx/conf/mime.types
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/nginx/mime.types
+++ b/nginx/mime.types
@@ -1,0 +1,96 @@
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -22,6 +22,14 @@ http {
 
   # error_page 404 /404.html;
 
+  log_format request_format '[$time_local] - $remote_addr, '
+                               '[connection-id: $connection current-number: $connection_requests], '
+                               '[$request $status], '
+                               '[referer: "$http_referer" user-agent: "$http_user_agent"], '
+                               '[size: $bytes_sent body-size: $body_bytes_sent], '
+                               '[rt: $request_time uct: $upstream_connect_time uht: $upstream_header_time urt: $upstream_response_time]';
+  open_log_file_cache max=1000 inactive=20s valid=1m min_uses=2;
+
   root   /front;
   server {
     listen       80;
@@ -35,6 +43,9 @@ http {
       open_file_cache_errors   off;
 
       index  index.html;
+
+      access_log /logs/front-access.log request_format;
+      error_log /logs/front-error.log;
     }
 
     location ^~ /api {
@@ -50,6 +61,9 @@ http {
       proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
 
       default_type  application/json;
+
+      access_log /logs/webchat-access.log request_format;
+      error_log /logs/webchat-error.log;
     }
 
     location /health {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,60 @@
+# http://nginx.org/en/docs/http/ngx_http_core_module.html
+worker_processes  auto;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+  sendfile            on;
+  tcp_nodelay         on;
+  include   mime.types;
+  connection_pool_size 128;
+  merge_slashes on;
+
+  keepalive_timeout   5;
+  keepalive_requests 500000;
+  types_hash_max_size 2048;
+
+  client_body_timeout 10s;
+  client_header_timeout 10s;
+  client_max_body_size 32m;
+
+  # error_page 404 /404.html;
+
+  root   /front;
+  server {
+    listen       80;
+    location / {
+      etag  on;
+      if_modified_since before;
+
+      open_file_cache          max=1000 inactive=5s;
+      open_file_cache_valid    5s;
+      open_file_cache_min_uses 2;
+      open_file_cache_errors   off;
+
+      index  index.html;
+    }
+
+    location ^~ /api {
+      resolver 10.0.0.2 valid=5s;
+      set $webchat "webchat.local:8080";
+
+      proxy_pass    http://$webchat;
+
+      proxy_http_version 1.1;
+      proxy_set_header    Host                $http_host;
+      proxy_set_header    X-Real-IP           $realip_remote_addr;
+      proxy_set_header    X-Forwarded-Proto   $scheme;
+      proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+
+      default_type  application/json;
+    }
+
+    location /health {
+        access_log off;
+        return 200 "healthy";
+    }
+  }
+}

--- a/nginx/task-definition.json
+++ b/nginx/task-definition.json
@@ -1,0 +1,96 @@
+{
+  "ipcMode": null,
+  "executionRoleArn": "ecsTaskExecutionRole",
+  "containerDefinitions": [
+    {
+      "dnsSearchDomains": null,
+      "logConfiguration": null,
+      "entryPoint": null,
+      "portMappings": [
+        {
+          "hostPort": 80,
+          "protocol": "tcp",
+          "containerPort": 80
+        }
+      ],
+      "command": null,
+      "linuxParameters": null,
+      "cpu": 0,
+      "environment": null,
+      "resourceRequirements": null,
+      "ulimits": null,
+      "dnsServers": null,
+      "mountPoints": [
+        {
+          "readOnly": null,
+          "containerPath": "/front",
+          "sourceVolume": "front"
+        }
+      ],
+      "workingDirectory": null,
+      "secrets": null,
+      "dockerSecurityOptions": null,
+      "memory": 128,
+      "volumesFrom": null,
+      "stopTimeout": 30,
+      "image": null,
+      "startTimeout": 180,
+      "firelensConfiguration": null,
+      "dependsOn": null,
+      "disableNetworking": false,
+      "interactive": null,
+      "healthCheck": {
+        "command": [
+          "CMD-SHELL",
+          "curl -f http://localhost/health || exit 1"
+        ],
+        "interval": 300,
+        "timeout": 5,
+        "retries": 3
+      },
+      "essential": true,
+      "links": [],
+      "hostname": null,
+      "extraHosts": null,
+      "pseudoTerminal": null,
+      "user": null,
+      "readonlyRootFilesystem": null,
+      "dockerLabels": null,
+      "systemControls": null,
+      "privileged": null,
+      "name": "nginx",
+      "repositoryCredentials": {
+        "credentialsParameter": ""
+      }
+    }
+  ],
+  "memory": "512",
+  "taskRoleArn": "ecsTaskExecutionRole",
+  "family": "nginx",
+  "pidMode": null,
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "networkMode": "awsvpc",
+  "cpu": "256",
+  "inferenceAccelerators": [],
+  "proxyConfiguration": null,
+  "volumes": [
+    {
+      "efsVolumeConfiguration": {
+        "transitEncryptionPort": null,
+        "fileSystemId": "fs-cac2c4ab",
+        "authorizationConfig": {
+          "iam": "DISABLED",
+          "accessPointId": "fsap-08273271435023193"
+        },
+        "transitEncryption": "ENABLED",
+        "rootDirectory": "/"
+      },
+      "name": "front",
+      "host": null,
+      "dockerVolumeConfiguration": null
+    }
+  ],
+  "tags": []
+}

--- a/nginx/task-definition.json
+++ b/nginx/task-definition.json
@@ -25,6 +25,11 @@
           "readOnly": null,
           "containerPath": "/front",
           "sourceVolume": "front"
+        },
+        {
+          "readOnly": null,
+          "containerPath": "/logs",
+          "sourceVolume": "logs"
         }
       ],
       "workingDirectory": null,
@@ -88,6 +93,21 @@
         "rootDirectory": "/"
       },
       "name": "front",
+      "host": null,
+      "dockerVolumeConfiguration": null
+    },
+    {
+      "efsVolumeConfiguration": {
+        "transitEncryptionPort": null,
+        "fileSystemId": "fs-cac2c4ab",
+        "authorizationConfig": {
+          "iam": "DISABLED",
+          "accessPointId": "fsap-066c4a71e5c166631"
+        },
+        "transitEncryption": "ENABLED",
+        "rootDirectory": "/"
+      },
+      "name": "logs",
       "host": null,
       "dockerVolumeConfiguration": null
     }

--- a/src/main/java/web/chat/backend/controller/HealthController.java
+++ b/src/main/java/web/chat/backend/controller/HealthController.java
@@ -1,0 +1,19 @@
+package web.chat.backend.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Created by koseungbin on 2020-08-19
+ */
+
+@RestController
+public class HealthController {
+	@GetMapping(path = "/health")
+	@ResponseStatus(HttpStatus.OK)
+	public String getMessages() {
+		return "healthy";
+	}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,18 @@
+server:
+  port: 8080
+
+spring:
+  datasource:
+    url: jdbc:mysql://host.docker.internal:3306/webchat?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: webchat
+    password: webchat
+    sql-script-encoding: UTF-8
+    initialization-mode: always
+  jpa:
+    database: mysql
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+      format-sql: true

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,14 +3,10 @@ server:
 
 spring:
   datasource:
-    url: jdbc:mysql://host.docker.internal:3306/webchat?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: webchat
-    password: webchat
     sql-script-encoding: UTF-8
     initialization-mode: always
   jpa:
     database: mysql
-    show-sql: true
     hibernate:
       ddl-auto: update
     properties:

--- a/task-definition.json
+++ b/task-definition.json
@@ -1,0 +1,72 @@
+{
+  "ipcMode": null,
+  "executionRoleArn": "ecsTaskExecutionRole",
+  "containerDefinitions": [
+    {
+      "dnsSearchDomains": null,
+      "environmentFiles": null,
+      "logConfiguration": null,
+      "entryPoint": null,
+      "portMappings": [
+        {
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "containerPort": 8080
+        }
+      ],
+      "command": null,
+      "linuxParameters": null,
+      "cpu": 512,
+      "environment": [],
+      "resourceRequirements": null,
+      "ulimits": null,
+      "dnsServers": null,
+      "mountPoints": [],
+      "workingDirectory": null,
+      "secrets": null,
+      "dockerSecurityOptions": null,
+      "memory": 1024,
+      "volumesFrom": [],
+      "stopTimeout": 30,
+      "image": null,
+      "startTimeout": 180,
+      "firelensConfiguration": null,
+      "dependsOn": null,
+      "disableNetworking": null,
+      "interactive": null,
+      "healthCheck": {
+        "command": [
+          "CMD-SHELL",
+          "curl -f http://localhost:8080/health || exit 1"
+        ],
+        "interval": 40,
+        "timeout": 5,
+        "retries": 3
+      },
+      "essential": true,
+      "links": null,
+      "hostname": null,
+      "extraHosts": null,
+      "pseudoTerminal": null,
+      "user": null,
+      "readonlyRootFilesystem": null,
+      "dockerLabels": null,
+      "systemControls": null,
+      "privileged": null,
+      "name": "webchat"
+    }
+  ],
+  "memory": "2048",
+  "taskRoleArn": "ecsTaskExecutionRole",
+  "family": "webchat",
+  "pidMode": null,
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "networkMode": "awsvpc",
+  "cpu": "1024",
+  "inferenceAccelerators": [],
+  "proxyConfiguration": null,
+  "volumes": [],
+  "tags": []
+}


### PR DESCRIPTION
## 🐣 변경 사항

### nginx 설정

- `~/api/` 경로에 대해서는 webchat 백엔드로 요청 라우팅
- `/` 경로는 빌드된 front 정적 파일 제공
- 5초마다 `webchat.local` 대한 ip를 DNS 에 요청한다.

### AWS ECS
- nginx, webchat 에 대한 Task Definition 추가
- 컨테이너 상태 확인을 위한 `/health` api 추가
- 컨테이너 빌드 시점에 DB 연결 정보 주입하도록 설정
  - DB 정보는 Github Secret에 설정
  - 기본적인 개발 서버 정보는 `application-dev.yml`에 정의

![image](https://user-images.githubusercontent.com/16451031/90971875-ea56fa80-e54e-11ea-95f6-a89b9b633d7e.png)


## 🧢 체크 리스트

- [ ] 테스트 코드를 포함하고 있나요?
- [X] 공통된 코드 스타일을 따르 있나요?

## 🍄 ps
