### PR TITLE
메시지 조회 기능에 대한 tc 추가

### DIFF
--- a/src/main/java/web/chat/backend/entity/Room.java
+++ b/src/main/java/web/chat/backend/entity/Room.java
@@ -20,8 +20,6 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity
-@Builder
-
 public class Room {
 
 	@Id

--- a/src/test/java/web/chat/backend/repository/MessageRepositoryTest.java
+++ b/src/test/java/web/chat/backend/repository/MessageRepositoryTest.java
@@ -1,6 +1,6 @@
 package web.chat.backend.repository;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,22 +37,24 @@ class MessageRepositoryTest {
 		Room room = new Room();
 		room.setTitle("spring study");
 
-		Room savedRoom = entityManager.persist(room);
+		Room givenRoom = entityManager.persist(room);
 
-		List<Message> savedMessages = Stream.of(1, 2, 3)
+		List<Message> givenMessages = Stream.of(1, 2, 3)
 			.map((id) -> {
 				Message message = new Message();
 				message.setContents("contents_" + id);
 				message.setMessageType(MessageType.TEXT);
-				message.setRoom(savedRoom);
+				message.setRoom(givenRoom);
 				return entityManager.persist(message);
 			}).collect(Collectors.toList());
 
 		// when
-		List<Message> messages = messageRepository.findAllByRoomId(savedRoom.getId());
+		List<Message> messages = messageRepository.findAllByRoomId(givenRoom.getId());
 
 		// then
-		assertEquals(savedMessages.size(), messages.size());
-		assertIterableEquals(savedMessages, messages);
+		assertThat(messages)
+			.hasSameSizeAs(givenMessages)
+			.usingRecursiveComparison()
+			.isEqualTo(givenMessages);
 	}
 }

--- a/src/test/java/web/chat/backend/repository/MessageRepositoryTest.java
+++ b/src/test/java/web/chat/backend/repository/MessageRepositoryTest.java
@@ -1,0 +1,58 @@
+package web.chat.backend.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.TestConstructor;
+
+import lombok.RequiredArgsConstructor;
+import web.chat.backend.entity.Message;
+import web.chat.backend.entity.MessageType;
+import web.chat.backend.entity.Room;
+
+/**
+ * Created by koseungbin on 2020-08-30
+ */
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+@DataJpaTest
+class MessageRepositoryTest {
+
+	final TestEntityManager entityManager;
+
+	final MessageRepository messageRepository;
+
+	@DisplayName("Room ID = 1 인 채팅방에 존재하는 모든 메시지 조회")
+	@Test
+	void shouldFindMessageEntities_WithRoomId_1() {
+		// given
+		Room room = new Room();
+		room.setTitle("spring study");
+
+		Room savedRoom = entityManager.persist(room);
+
+		List<Message> savedMessages = Stream.of(1, 2, 3)
+			.map((id) -> {
+				Message message = new Message();
+				message.setContents("contents_" + id);
+				message.setMessageType(MessageType.TEXT);
+				message.setRoom(savedRoom);
+				return entityManager.persist(message);
+			}).collect(Collectors.toList());
+
+		// when
+		List<Message> messages = messageRepository.findAllByRoomId(savedRoom.getId());
+
+		// then
+		assertEquals(savedMessages.size(), messages.size());
+		assertIterableEquals(savedMessages, messages);
+	}
+}

--- a/src/test/java/web/chat/backend/service/MessageServiceTest.java
+++ b/src/test/java/web/chat/backend/service/MessageServiceTest.java
@@ -1,0 +1,92 @@
+package web.chat.backend.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import lombok.RequiredArgsConstructor;
+import web.chat.backend.entity.Message;
+import web.chat.backend.entity.MessageType;
+import web.chat.backend.exception.NotFoundException;
+import web.chat.backend.repository.MessageRepository;
+
+/**
+ * Created by koseungbin on 2020-08-29
+ */
+
+@ExtendWith(MockitoExtension.class)
+@RequiredArgsConstructor
+class MessageServiceTest {
+
+	@InjectMocks
+	MessageService messageService;
+
+	@Mock
+	MessageRepository messageRepository;
+
+	@DisplayName("Room 존재하지 않는 경우 NotFoundException 에러 발생")
+	@Test
+	void shouldThrowNotFoundException_ifNotExist_roomId() {
+		// given
+		Long roomId = 1L;
+		given(messageRepository.existsByRoomId(roomId)).willReturn(false);
+
+		// when, then
+		assertThrows(NotFoundException.class, () -> messageService.getMessagesBy(roomId));
+	}
+
+	@DisplayName("Room 존재하는 경우 메시지 리스트 반환")
+	@Test
+	void shouldMessages_ifExist_roomId() {
+		// given
+		Long roomId = 1L;
+		given(messageRepository.existsByRoomId(roomId)).willReturn(true);
+
+		LocalDateTime now = LocalDateTime.now();
+		List<Message> givenMessages = Stream.of(1, 2, 3).map((id) -> {
+			Message message = new Message();
+			message.setId((long)id);
+			message.setContents("contents_" + id);
+			message.setCreatedAt(now.plusDays(id));
+			message.setMessageType(MessageType.TEXT);
+			return message;
+		}).collect(Collectors.toList());
+
+		given(messageRepository.findAllByRoomId(roomId)).willReturn(givenMessages);
+
+		// when
+		List<Message> messages = messageService.getMessagesBy(roomId);
+
+		// then
+		assertEquals(3, messages.size());
+		assertIterableEquals(givenMessages, messages);
+		then(messageRepository).should(times(1)).existsByRoomId(roomId);
+		then(messageRepository).should(times(1)).findAllByRoomId(roomId);
+	}
+
+	@DisplayName("Room 존재하는 경우 Room ID = 1 으로 메시드를 한 번씩 호출")
+	@Test
+	void verifyMessages_ifExist_roomId() {
+		// given
+		Long roomId = 1L;
+		given(messageRepository.existsByRoomId(roomId)).willReturn(true);
+
+		// when
+		messageService.getMessagesBy(roomId);
+
+		// then
+		then(messageRepository).should(times(1)).existsByRoomId(roomId);
+		then(messageRepository).should(times(1)).findAllByRoomId(roomId);
+	}
+}

--- a/src/test/java/web/chat/backend/service/MessageServiceTest.java
+++ b/src/test/java/web/chat/backend/service/MessageServiceTest.java
@@ -3,7 +3,6 @@ package web.chat.backend.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -53,12 +52,10 @@ class MessageServiceTest {
 		Long roomId = 1L;
 		given(messageRepository.existsByRoomId(roomId)).willReturn(true);
 
-		LocalDateTime now = LocalDateTime.now();
 		List<Message> givenMessages = Stream.of(1, 2, 3).map((id) -> {
 			Message message = new Message();
 			message.setId((long)id);
 			message.setContents("contents_" + id);
-			message.setCreatedAt(now.plusDays(id));
 			message.setMessageType(MessageType.TEXT);
 			return message;
 		}).collect(Collectors.toList());

--- a/src/test/java/web/chat/backend/service/MessageServiceTest.java
+++ b/src/test/java/web/chat/backend/service/MessageServiceTest.java
@@ -1,6 +1,6 @@
 package web.chat.backend.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.List;
@@ -42,7 +42,10 @@ class MessageServiceTest {
 		given(messageRepository.existsByRoomId(roomId)).willReturn(false);
 
 		// when, then
-		assertThrows(NotFoundException.class, () -> messageService.getMessagesBy(roomId));
+		assertThatExceptionOfType(NotFoundException.class)
+			.isThrownBy(() -> messageService.getMessagesBy(roomId))
+			.withMessage("%d does not exist.", roomId)
+			.withNoCause();
 	}
 
 	@DisplayName("Room 존재하는 경우 메시지 리스트 반환")
@@ -66,8 +69,10 @@ class MessageServiceTest {
 		List<Message> messages = messageService.getMessagesBy(roomId);
 
 		// then
-		assertEquals(3, messages.size());
-		assertIterableEquals(givenMessages, messages);
+		assertThat(messages)
+			.hasSameSizeAs(givenMessages)
+			.usingRecursiveComparison()
+			.isEqualTo(givenMessages);
 	}
 
 	@DisplayName("Room 존재하는 경우 Room ID = 1 으로 메시드를 한 번씩 호출")

--- a/src/test/java/web/chat/backend/service/MessageServiceTest.java
+++ b/src/test/java/web/chat/backend/service/MessageServiceTest.java
@@ -68,8 +68,6 @@ class MessageServiceTest {
 		// then
 		assertEquals(3, messages.size());
 		assertIterableEquals(givenMessages, messages);
-		then(messageRepository).should(times(1)).existsByRoomId(roomId);
-		then(messageRepository).should(times(1)).findAllByRoomId(roomId);
 	}
 
 	@DisplayName("Room 존재하는 경우 Room ID = 1 으로 메시드를 한 번씩 호출")


### PR DESCRIPTION
### ⚽ 기능 설명

- 메시지 조회 기능에 대한 Service 단위 테스트 추가
- 메시지 조회 기능에 대한 JPA 테스트 추가
- 중복된 `@Builder` 로 인한 컴파일 에러 제거

## 🏷  연관 이슈

> #26 

## 🧢 체크 리스트

- [X] 테스트 코드를 포함하고 있나요?
- [X] 공통된 코드 스타일을 따르 있나요?

## 🍄 ps
