### PR TITLE
채팅방 입장시 메시지가 없으면 에러 발생

### DIFF
--- a/src/main/java/web/chat/backend/controller/RoomController.java
+++ b/src/main/java/web/chat/backend/controller/RoomController.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import web.chat.backend.controller.request.MessageRequest;
 import web.chat.backend.controller.request.RoomRequest;
 import web.chat.backend.controller.response.MessageResponse;
+import web.chat.backend.controller.response.MessagesResponse;
 import web.chat.backend.controller.response.RoomResponse;
 import web.chat.backend.controller.response.RoomsResponse;
 import web.chat.backend.controller.response.collector.MessageCollector;
@@ -48,7 +49,7 @@ public class RoomController {
 
 	@GetMapping(value = "/{id}/messages")
 	@ResponseStatus(HttpStatus.OK)
-	public List<MessageResponse> getMessages(@PathVariable Long id) {
+	public MessagesResponse getMessages(@PathVariable Long id) {
 		List<Message> messages = messageService.getMessagesBy(id);
 		return messages.stream().collect(new MessageCollector());
 	}

--- a/src/main/java/web/chat/backend/controller/response/MessagesResponse.java
+++ b/src/main/java/web/chat/backend/controller/response/MessagesResponse.java
@@ -1,0 +1,16 @@
+package web.chat.backend.controller.response;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Created by koseungbin on 2020-08-30
+ */
+
+@Getter
+@RequiredArgsConstructor
+public class MessagesResponse {
+	final private List<MessageResponse> messages;
+}

--- a/src/main/java/web/chat/backend/controller/response/collector/MessageCollector.java
+++ b/src/main/java/web/chat/backend/controller/response/collector/MessageCollector.java
@@ -35,10 +35,7 @@ public class MessageCollector implements Collector<Message, List<MessageResponse
 
 	@Override
 	public BiConsumer<List<MessageResponse>, Message> accumulator() {
-		return (list, message) -> {
-			System.out.println(new MessageResponse(message));
-			list.add(new MessageResponse(message));
-		};
+		return (list, message) -> list.add(new MessageResponse(message));
 	}
 
 	@Override

--- a/src/main/java/web/chat/backend/controller/response/collector/MessageCollector.java
+++ b/src/main/java/web/chat/backend/controller/response/collector/MessageCollector.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import web.chat.backend.controller.response.MessageResponse;
+import web.chat.backend.controller.response.MessagesResponse;
 import web.chat.backend.entity.Message;
 
 /**
@@ -25,7 +26,7 @@ import web.chat.backend.entity.Message;
  * reference by : https://blog.indrek.io/articles/creating-a-collector-in-java-8/
  */
 
-public class MessageCollector implements Collector<Message, List<MessageResponse>, List<MessageResponse>> {
+public class MessageCollector implements Collector<Message, List<MessageResponse>, MessagesResponse> {
 
 	@Override
 	public Supplier<List<MessageResponse>> supplier() {
@@ -34,7 +35,10 @@ public class MessageCollector implements Collector<Message, List<MessageResponse
 
 	@Override
 	public BiConsumer<List<MessageResponse>, Message> accumulator() {
-		return (list, message) -> list.add(new MessageResponse(message));
+		return (list, message) -> {
+			System.out.println(new MessageResponse(message));
+			list.add(new MessageResponse(message));
+		};
 	}
 
 	@Override
@@ -46,12 +50,12 @@ public class MessageCollector implements Collector<Message, List<MessageResponse
 	}
 
 	@Override
-	public Function<List<MessageResponse>, List<MessageResponse>> finisher() {
-		return Function.identity();
+	public Function<List<MessageResponse>, MessagesResponse> finisher() {
+		return MessagesResponse::new;
 	}
 
 	@Override
 	public Set<Characteristics> characteristics() {
-		return Collections.unmodifiableSet(EnumSet.of(IDENTITY_FINISH));
+		return Collections.unmodifiableSet(EnumSet.of(CONCURRENT));
 	}
 }

--- a/src/main/java/web/chat/backend/service/MessageService.java
+++ b/src/main/java/web/chat/backend/service/MessageService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import web.chat.backend.entity.Message;
 import web.chat.backend.entity.Room;
-import web.chat.backend.exception.NotFoundException;
 import web.chat.backend.repository.MessageRepository;
 
 @Service
@@ -16,10 +15,6 @@ public class MessageService {
 	private final MessageRepository messageRepository;
 
 	public List<Message> getMessagesBy(Long roomId) {
-		if (!messageRepository.existsByRoomId(roomId)) {
-			throw new NotFoundException(roomId);
-		}
-
 		return messageRepository.findAllByRoomId(roomId);
 	}
 

--- a/src/test/java/web/chat/backend/controller/RoomControllerIntegrationTest.java
+++ b/src/test/java/web/chat/backend/controller/RoomControllerIntegrationTest.java
@@ -38,13 +38,13 @@ class RoomControllerIntegrationTest {
 	@DisplayName("ID가 1인 채팅방의 메시지 리스트가 조회되야만 한다")
 	void shouldGetMessageList_inRoomIdWith1() throws Exception {
 		mockMvc.perform(get("/api/rooms/{id}/messages", 1))
+			.andDo(print())
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.*", not(empty())))
 			.andExpect(jsonPath("$.*", hasSize(1)))
 			.andExpect(jsonPath("$.messages[0].id", is(1)))
 			.andExpect(jsonPath("$.messages[0].contents", is("foo")))
-			.andExpect(jsonPath("$.messages[0].messageType", is("TEXT")))
-			.andDo(print());
+			.andExpect(jsonPath("$.messages[0].messageType", is("TEXT")));
 	}
 
 	@Test
@@ -63,8 +63,9 @@ class RoomControllerIntegrationTest {
 		ResultActions resultActions = mockMvc.perform(get("/api/rooms"));
 
 		// then
-		resultActions.andExpect(status().isOk())
-			.andDo(print());
+		resultActions
+			.andDo(print())
+			.andExpect(status().isOk());
 	}
 
 	@Test
@@ -82,8 +83,8 @@ class RoomControllerIntegrationTest {
 				.content(body));
 
 		// then
-		action.andExpect(status().isCreated())
-			.andDo(print());
-
+		action
+			.andDo(print())
+			.andExpect(status().isCreated());
 	}
 }

--- a/src/test/java/web/chat/backend/controller/RoomControllerIntegrationTest.java
+++ b/src/test/java/web/chat/backend/controller/RoomControllerIntegrationTest.java
@@ -5,17 +5,15 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -29,19 +27,11 @@ import web.chat.backend.controller.request.RoomRequest;
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 @RequiredArgsConstructor
 @SpringBootTest
+@AutoConfigureMockMvc
 class RoomControllerIntegrationTest {
 	final ObjectMapper objectMapper;
 	final RoomController roomController;
-	private MockMvc mockMvc;
-
-	@BeforeEach
-	void setup() {
-		mockMvc = MockMvcBuilders
-			.standaloneSetup(roomController)
-			.setControllerAdvice(new ExceptionController())
-			.addFilters(new CharacterEncodingFilter("UTF-8", true))
-			.build();
-	}
+	final MockMvc mockMvc;
 
 	@Test
 	@Sql("/test-sql/messages.sql")

--- a/src/test/java/web/chat/backend/controller/RoomControllerIntegrationTest.java
+++ b/src/test/java/web/chat/backend/controller/RoomControllerIntegrationTest.java
@@ -1,14 +1,9 @@
 package web.chat.backend.controller;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.Objects;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +21,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import web.chat.backend.controller.request.RoomRequest;
-import web.chat.backend.exception.NotFoundException;
 
 /**
  * Created by koseungbin on 2020-08-15
@@ -38,7 +32,7 @@ import web.chat.backend.exception.NotFoundException;
 class RoomControllerIntegrationTest {
 	final ObjectMapper objectMapper;
 	final RoomController roomController;
-	MockMvc mockMvc;
+	private MockMvc mockMvc;
 
 	@BeforeEach
 	void setup() {
@@ -64,14 +58,12 @@ class RoomControllerIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("존재하지 않은 채팅방을 요청한 경우에는 400 응답코드를 반환해야만 한다")
+	@DisplayName("채팅방에 메시지가 하나도 없는 경우 빈 메시지 리스트를 반환해야만 한다")
 	void shouldRespond400StatusCode_ifNotFoundRoom() throws Exception {
 		mockMvc.perform(get("/api/rooms/{id}/messages", 100))
-			.andExpect(status().isBadRequest())
-			.andExpect(result -> assertThat(result.getResolvedException() instanceof NotFoundException).isTrue())
-			.andExpect(result -> assertEquals(Objects.requireNonNull(result.getResolvedException()).getMessage(),
-				"100 does not exist."))
-			.andDo(print());
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$", empty()));
 	}
 
 	@Test

--- a/src/test/java/web/chat/backend/controller/RoomControllerIntegrationTest.java
+++ b/src/test/java/web/chat/backend/controller/RoomControllerIntegrationTest.java
@@ -51,9 +51,9 @@ class RoomControllerIntegrationTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.*", not(empty())))
 			.andExpect(jsonPath("$.*", hasSize(1)))
-			.andExpect(jsonPath("$[0].id", is(1)))
-			.andExpect(jsonPath("$[0].contents", is("foo")))
-			.andExpect(jsonPath("$[0].messageType", is("TEXT")))
+			.andExpect(jsonPath("$.messages[0].id", is(1)))
+			.andExpect(jsonPath("$.messages[0].contents", is("foo")))
+			.andExpect(jsonPath("$.messages[0].messageType", is("TEXT")))
 			.andDo(print());
 	}
 
@@ -63,7 +63,7 @@ class RoomControllerIntegrationTest {
 		mockMvc.perform(get("/api/rooms/{id}/messages", 100))
 			.andDo(print())
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$", empty()));
+			.andExpect(jsonPath("$.messages", empty()));
 	}
 
 	@Test

--- a/src/test/java/web/chat/backend/controller/RoomControllerTest.java
+++ b/src/test/java/web/chat/backend/controller/RoomControllerTest.java
@@ -1,15 +1,13 @@
 package web.chat.backend.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 
 import java.util.Arrays;
 import java.util.List;
@@ -25,6 +23,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.RequiredArgsConstructor;
 import web.chat.backend.controller.request.MessageRequest;
 import web.chat.backend.controller.request.RoomRequest;
@@ -72,13 +71,14 @@ class RoomControllerTest {
 		ResultActions resultActions = mockMvc.perform(get("/api/rooms"));
 
 		// then
-		resultActions.andExpect(status().isOk())
+		resultActions
+			.andDo(print())
+			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.rooms", not(empty())))
 			.andExpect(jsonPath("$.rooms", hasSize(3)))
 			.andExpect(jsonPath("$.rooms[0].id", is(1)))
 			.andExpect(jsonPath("$.rooms[1].id", is(2)))
-			.andExpect(jsonPath("$.rooms[2].id", is(3)))
-			.andDo(print());
+			.andExpect(jsonPath("$.rooms[2].id", is(3)));
 	}
 
 	@Test
@@ -105,9 +105,10 @@ class RoomControllerTest {
 				.content(body));
 
 		// then
-		action.andExpect(status().isCreated())
-			.andExpect(content().string(expected))
-			.andDo(print());
+		action
+			.andDo(print())
+			.andExpect(status().isCreated())
+			.andExpect(content().string(expected));
 	}
 
 	@DisplayName("Room의 title 길이 2미만 불가능")
@@ -126,9 +127,10 @@ class RoomControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(body));
 		// then
-		action.andExpect(status().is4xxClientError())
-			.andExpect(result -> assertTrue(result.getResolvedException() instanceof MethodArgumentNotValidException))
-			.andDo(print());
+		action
+			.andDo(print())
+			.andExpect(status().is4xxClientError())
+			.andExpect(result -> assertTrue(result.getResolvedException() instanceof MethodArgumentNotValidException));
 	}
 
 	@DisplayName("Room의 title 길이 20초과 불가능")
@@ -148,9 +150,10 @@ class RoomControllerTest {
 				.content(body));
 
 		// then
-		resultActions.andExpect(status().is4xxClientError())
-			.andExpect(result -> assertTrue(result.getResolvedException() instanceof MethodArgumentNotValidException))
-			.andDo(print());
+		resultActions
+			.andDo(print())
+			.andExpect(status().is4xxClientError())
+			.andExpect(result -> assertTrue(result.getResolvedException() instanceof MethodArgumentNotValidException));
 
 	}
 

--- a/src/test/java/web/chat/backend/service/MessageServiceTest.java
+++ b/src/test/java/web/chat/backend/service/MessageServiceTest.java
@@ -17,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import lombok.RequiredArgsConstructor;
 import web.chat.backend.entity.Message;
 import web.chat.backend.entity.MessageType;
-import web.chat.backend.exception.NotFoundException;
 import web.chat.backend.repository.MessageRepository;
 
 /**
@@ -34,27 +33,11 @@ class MessageServiceTest {
 	@Mock
 	MessageRepository messageRepository;
 
-	@DisplayName("Room 존재하지 않는 경우 NotFoundException 에러 발생")
-	@Test
-	void shouldThrowNotFoundException_ifNotExist_roomId() {
-		// given
-		Long roomId = 1L;
-		given(messageRepository.existsByRoomId(roomId)).willReturn(false);
-
-		// when, then
-		assertThatExceptionOfType(NotFoundException.class)
-			.isThrownBy(() -> messageService.getMessagesBy(roomId))
-			.withMessage("%d does not exist.", roomId)
-			.withNoCause();
-	}
-
 	@DisplayName("Room 존재하는 경우 메시지 리스트 반환")
 	@Test
 	void shouldMessages_ifExist_roomId() {
 		// given
 		Long roomId = 1L;
-		given(messageRepository.existsByRoomId(roomId)).willReturn(true);
-
 		List<Message> givenMessages = Stream.of(1, 2, 3).map((id) -> {
 			Message message = new Message();
 			message.setId((long)id);
@@ -73,20 +56,5 @@ class MessageServiceTest {
 			.hasSameSizeAs(givenMessages)
 			.usingRecursiveComparison()
 			.isEqualTo(givenMessages);
-	}
-
-	@DisplayName("Room 존재하는 경우 Room ID = 1 으로 메시드를 한 번씩 호출")
-	@Test
-	void verifyMessages_ifExist_roomId() {
-		// given
-		Long roomId = 1L;
-		given(messageRepository.existsByRoomId(roomId)).willReturn(true);
-
-		// when
-		messageService.getMessagesBy(roomId);
-
-		// then
-		then(messageRepository).should(times(1)).existsByRoomId(roomId);
-		then(messageRepository).should(times(1)).findAllByRoomId(roomId);
 	}
 }


### PR DESCRIPTION
## 🐣 변경 사항

- 채팅방 입장시, 400 에러 해결
  =>  원인 : 메시지 목록을 기준으로 채팅방 존재 여부를 검사했기 때문에, 메시지가 없는 경우에는 반드시 에러가 발생
  =>  채팅방 존재 여부 로직 확인 제거 

- 메시지 리스트 조회 요청에 대한 응답 데이터 형식 변경
  => 기존에 리스트 형태로 응답
  ```json
   [
      { 
           "id": 1,
           // ...
       },
      { 
           "id": 2,
           // ...
       }
   ]
  ```
   => json 형식에 맞추어 오브젝트 형태로 변경
  ```json
   {
      "messages" : [
         { 
              "id": 1,
              // ...
         },
        { 
              "id": 2,
              // ...
         }
      ]
   }
  ```

- 테스트 케이스 실패한 경우에도 에러 메시지 출력하도록 `.andDo(print())` 상단 배치

## 🏷 연관 이슈

> #28 

## 🧢  체크 리스트

- [X] 테스트 코드를 포함하고 있나요?
- [X] 공통된 코드 스타일을 따르 있나요?

## 🍄 ps
