### PR TITLE
잘못된 경로로 접근한 경우, 디폴트 페이지로 이동할 수 있도록 nginx 설정 추가

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,5 @@
 # docker build -t nginx ./nginx
-# docker run --name nginx -d -p 8080:80 -v front:/front:ro --link web-chat nginx
+# docker run --name nginx -d -p 8080:80 -v front:/front:ro -v logs:/logs --link web-chat nginx
 FROM nginx
 
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -45,6 +45,7 @@ http {
       open_file_cache_errors   off;
 
       index  index.html;
+      try_files $uri $uri/ /index.html;
 
       access_log /logs/front-access.log request_format;
       error_log /logs/front-error.log;


### PR DESCRIPTION
## 🐣 변경 사항

- front 루트 디렉터리에서 uri 해당하는 리소스 존재 여부를 확인
  => `/front/uri` 경로에 해당하는 리소스 없을시,  index.html 파일을 응답하도록 설정
  * 리다이렉션이 일어나는 것이 아니기 때문에, 기존 경로는 그대로 유지된다.
  * 따라서, index.html 파일을 내려받고 나서 브라우저에서 '*' 경로로 라우팅된다. (ref. LandvibeDev/web-chat-frontend#32)

- ref. http://nginx.org/en/docs/http/ngx_http_core_module.html#try_files

## 🏷 연관 이슈

> #32 

## 🧢 체크 리스트

- [ ] 테스트 코드를 포함하고 있나요?
- [X] 공통된 코드 스타일을 따르 있나요?

## 🍄 ps
